### PR TITLE
Basic Makefile for building local image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+PROJECT_DIR := /Users/jay/Projects/hashmap/thingsboard
+CURRENT_DIR := $(shell pwd)
+
+all:install copy build	
+
+install:
+	mvn -f ${PROJECT_DIR}/pom.xml clean install -DskipTests
+
+copy:
+	cp ${PROJECT_DIR}/application/target/thingsboard.deb ${CURRENT_DIR}/tb
+
+build:
+	docker-compose stop
+	docker-compose build
+	docker-compose up -d


### PR DESCRIPTION
Simple file to execute all commands to build local docker image.

Just configure Project base directory, and execute "make" command.

We can also have profiles in pom.xml which can trigger for docker build for local environment at the time of deployment.